### PR TITLE
fixed issue with influxdb package location

### DIFF
--- a/monger.go
+++ b/monger.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/beevik/ntp"
-	"github.com/influxdb/influxdb/client"
+	"github.com/influxdata/influxdb/client"
 	"github.com/iron-io/iron_go3/api"
 	"github.com/iron-io/iron_go3/config"
 	"github.com/iron-io/iron_go3/mq"


### PR DESCRIPTION
without this fix I kept getting the error

```
monger.go:16:2: code in directory /Users/noqcks/go/src/github.com/influxdb/influxdb/client expects import "github.com/influxdata/influxdb/client"
```
